### PR TITLE
Auth/Account related work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@
 .pnp.js
 .yarn/install-state.gz
 
+# VS Code
+.vscode
+
 # testing
 /coverage
 

--- a/src/app/_components/ComingSoonSmall.js
+++ b/src/app/_components/ComingSoonSmall.js
@@ -6,8 +6,8 @@ function ComingSoonSmall({ showSignUp }) {
       Coming Soon!
       {showSignUp ? (
         <Link
-          href="/account/signup"
-          className="border border-primary-700 py-1 px-2 rounded-md mx-2 text-lg inline-block hover:bg-accent-600 transition-all hover:text-primary-950"
+          href="/account/verify-human"
+          className="border border-primary-700 py-1 px-2 rounded-md mx-2 text-lg inline-block hover:bg-accent-600 transition-all hover:text-primary-50"
         >
           Sign up now &rarr;
         </Link>

--- a/src/app/_components/LoginForm.js
+++ b/src/app/_components/LoginForm.js
@@ -30,6 +30,12 @@ function LoginForm() {
         toast.success("You've successfully logged in!", {
           id: "loggedIn",
           position: "top-right",
+          duration: 2000,
+          style: {
+            borderRadius: "10px",
+            background: "#333",
+            color: "#fff",
+          },
         });
         router.push("/records");
       } else if (message === "error") {
@@ -65,7 +71,6 @@ function LoginForm() {
               placeholder="Email"
               value={email}
               onChange={handleEmail}
-              autoFocus
             />
           </div>
           <div className="flex w-full content-center pb-4">

--- a/src/app/_components/Navigation.js
+++ b/src/app/_components/Navigation.js
@@ -53,7 +53,7 @@ export default function Navigation() {
               href="/account/login"
               className="hover:text-accent-400 transition-colors"
             >
-              Log In/Sign Up
+              Log In/Join
             </Link>
           )}
         </li>

--- a/src/app/_components/ResendConfirmation.js
+++ b/src/app/_components/ResendConfirmation.js
@@ -1,10 +1,13 @@
 "use client";
 
 import SubmitButton from "@/src/app/_components/SubmitButton";
-import { serverResend } from "@/src/app/_library/serverActions";
+import {
+  serverResend,
+  serverResetPassword,
+} from "@/src/app/_library/serverActions";
 import { useActionState } from "react";
 
-function ResendConfirmation({ email }) {
+function ResendConfirmation({ email, action }) {
   // this needs to display a message to the user
   // that the confirmation email has been sent
   // and to check their email
@@ -12,12 +15,23 @@ function ResendConfirmation({ email }) {
   // and to check their junk folder
   // and to check their promotions folder
   // and to check their social folder
-  const [state, formAction, isPending] = useActionState(serverResend, {});
+  let serverAction = null;
+  switch (action) {
+    case "signup":
+      serverAction = serverResend;
+      break;
+    case "reset":
+      serverAction = serverResetPassword;
+      break;
+    default:
+      console.log(`ResendConfirmation: action ${action} not found`);
+  }
+  const [state, formAction, isPending] = useActionState(serverAction, {});
   return (
     <form action={formAction} className="w-full content-center">
       <input type="hidden" name="email" value={email} />
       <SubmitButton
-        disabled={isPending}
+        disabled={isPending || !serverAction}
         cssClasses="bg-accent-500 mb-3 mt-3 mr-4 px-3 py-2 font-bold h-[40px] text-primary-50 border-primary-500 rounded-md"
       >
         Resend Confirmation

--- a/src/app/_components/ResetPasswordForm.js
+++ b/src/app/_components/ResetPasswordForm.js
@@ -29,7 +29,7 @@ function ResetPasswordForm() {
         toast.error("🤒 There was an error resetting your password.");
       }
     }
-  }, [state, setEmail, router]);
+  }, [state, setEmail, email, router]);
 
   function handleEmail(e) {
     setEmail(e.target.value);

--- a/src/app/_components/ResetPasswordForm.js
+++ b/src/app/_components/ResetPasswordForm.js
@@ -6,6 +6,7 @@ import { serverResetPassword } from "@/src/app/_library/serverActions";
 import SpinnerMini from "@/src/app/_components/SpinnerMini";
 import { validateEmail } from "@/src/app/_library/utilities";
 import toast, { Toaster } from "react-hot-toast";
+import SubmitButton from "./SubmitButton";
 const initialState = { message: "" };
 function ResetPasswordForm() {
   const router = useRouter();
@@ -14,13 +15,15 @@ function ResetPasswordForm() {
     initialState
   );
   const [email, setEmail] = useState("");
-  const isSubmittable = validateEmail(email);
+  const isValidEmail = validateEmail(email);
 
   useEffect(() => {
     if (state) {
       const { message } = state;
       if (message === "success") {
-        toast.success("Check your email for password update instructions.");
+        router.push(
+          `/account/check-email/${encodeURIComponent(email)}?action=reset`
+        );
       } else if (message === "error") {
         setEmail("");
         toast.error("🤒 There was an error resetting your password.");
@@ -33,29 +36,34 @@ function ResetPasswordForm() {
   }
   return (
     <div>
+      <Toaster />
       <form action={formAction}>
-        <div className="grid-flow-row">
-          <div className="form-row">
-            <label htmlFor="email">Email:&nbsp;</label>
+        <div className="grid-flow-row w-full box-border">
+          <div className="flex w-full content-center pt-3 pb-4">
             <input
               name="email"
               type="email"
-              className={`rounded-md border ${
-                isSubmittable ? "border-green-500" : "border-accent-500"
+              className={`rounded-md w-full p-3 text-lg text-primary-900 ${
+                !isValidEmail && "border border-red-600"
               }`}
               placeholder="Email"
               value={email}
               onChange={handleEmail}
+              autoFocus
+              required
             />
           </div>
-          <div>
-            <button
-              disabled={!isSubmittable}
-              className="bg-accent-600 mb-3 mt-3 mr-4 ml-4 px-3 py-1  border-primary-500 rounded-md"
+          <div className="flex w-full content-center">
+            <SubmitButton
+              disabled={!isValidEmail}
+              cssClasses={
+                isValidEmail
+                  ? `rounded-md bg-yellow-600 font-bold px-3 py-2 w-full text-2xl hover:bg-accent-600 active:bg-yellow-500`
+                  : `rounded-md bg-primary-500 font-bold px-3 py-2 w-full text-2xl`
+              }
             >
               {isPending ? <SpinnerMini /> : "Reset My Password"}
-            </button>
-            <Toaster />
+            </SubmitButton>
           </div>
         </div>
       </form>

--- a/src/app/_components/SignUp.js
+++ b/src/app/_components/SignUp.js
@@ -5,24 +5,24 @@ const rubikDoodleShadow = Rubik_Doodle_Shadow({
   weight: "400",
   subsets: ["symbols"],
 });
-function SignUp() {
+function SignUp({ captchaToken }) {
   return (
     <div className="relative flex grid-cols-3">
       <div className="w-1/3"></div>
       <div className="relative z-10 text-center w-1/3">
         <div
-          className={`w-full text-5xl text-center font-bold text-accent-500 mb-5 mt-5 justify-center ${rubikDoodleShadow.className}`}
+          className={`w-full text-5xl text-center font-bold text-accent-50 mb-5 mt-5 justify-center ${rubikDoodleShadow.className}`}
         >
           SIGN UP
         </div>
         <p className="text-justify pb-0 text-xl font-semibold text-primary-200">
-          Sign up early for an account and get a 10% coupon!
+          Sign up early for an account and get 10% off your first purchase!
         </p>
         <p className="text-justify pb-0 text-xl text-primary-300">
           Plus, we&apos;ll email you to let you know the day we{" "}
           <i>kick start</i> our store!
         </p>
-        <SignUpForm hCaptchaSiteKey={process.env.NEXT_HCAPTCHA_SITEKEY} />
+        <SignUpForm token={captchaToken} />
       </div>
       <div className="w-1/3"></div>
     </div>

--- a/src/app/_components/SignUpCaptcha.js
+++ b/src/app/_components/SignUpCaptcha.js
@@ -1,0 +1,67 @@
+"use client";
+import HCaptcha from "@hcaptcha/react-hcaptcha";
+import { useRouter } from "next/navigation";
+import React, { useEffect, useRef, useState } from "react";
+import toast, { Toaster } from "react-hot-toast";
+
+const SignUpCaptcha = ({ siteKey }) => {
+  const [token, setToken] = useState("");
+  const router = useRouter();
+  const captchaRef = useRef(null);
+  const onLoad = () => {
+    captchaRef.current.execute();
+  };
+  const disableSubmit = token === "";
+  useEffect(() => {
+    if (token !== "") {
+      // Perform any action with the token if needed
+      console.log("Captcha token:", token);
+    }
+  }, [token]);
+  const handleSubmit = () => {
+    if (token !== "") {
+      captchaRef.current.resetCaptcha();
+      // Redirect to the signup page or perform any other action
+      router.push(`/account/signup?captchaToken=${token}`);
+    } else {
+      toast.error(
+        "There was an error. Please complete the captcha to proceed."
+      );
+    }
+  };
+
+  return (
+    <>
+      <Toaster />
+      <div className="grid-flow-row w-full box-border">
+        <div className="flex p-2 mt-2 justify-center">
+          <HCaptcha
+            sitekey={siteKey}
+            onLoad={onLoad}
+            onVerify={setToken}
+            ref={captchaRef}
+            className="w-full"
+          />
+          {/* <input
+            type="hidden"
+            name="captchaToken"
+            value={token}
+            readOnly={true}
+          /> */}
+        </div>
+        <button
+          disabled={disableSubmit}
+          onClick={handleSubmit}
+          className={`border border-primary-700 py-2 px-4 rounded-md mx-2 text-lg font-bold inline-block ${
+            !disableSubmit &&
+            "hover:bg-accent-600 transition-all hover:text-primary-50 hover:cursor-pointer"
+          }`}
+        >
+          Continue &rarr;
+        </button>
+      </div>
+    </>
+  );
+};
+
+export default SignUpCaptcha;

--- a/src/app/_components/SignUpConfirmation.js
+++ b/src/app/_components/SignUpConfirmation.js
@@ -1,0 +1,21 @@
+function SignUpConfirmation({ showNote }) {
+  return (
+    <div>
+      <p>
+        Please check your email for a confirmation link to complete your account
+        setup.
+      </p>
+      <p>
+        If you don&apos;t see the email, please check your spam or junk folder.{" "}
+        {showNote && (
+          <i>
+            Note: you won&apos;t receive another confirmation if you are already
+            signed up.
+          </i>
+        )}
+      </p>
+    </div>
+  );
+}
+
+export default SignUpConfirmation;

--- a/src/app/_components/SignUpForm.js
+++ b/src/app/_components/SignUpForm.js
@@ -2,18 +2,19 @@
 
 import SubmitButton from "@/src/app/_components/SubmitButton";
 import { serverSignUp } from "@/src/app/_library/serverActions";
-import HCaptcha from "@hcaptcha/react-hcaptcha";
-import { useActionState, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useActionState, useEffect, useState } from "react";
 
 const initialState = {
   data: {},
 };
-function SignUpForm({ hCaptchaSiteKey }) {
+function SignUpForm({ token }) {
+  const router = useRouter();
   const [state, formAction, isPending] = useActionState(
     serverSignUp,
     initialState
   );
-  const [token, setToken] = useState("");
+  // const [token, setToken] = useState("");
   const [firstName, setFirstName] = useState("");
   const [lastName, setLastName] = useState("");
   const [email, setEmail] = useState("");
@@ -26,31 +27,27 @@ function SignUpForm({ hCaptchaSiteKey }) {
     email !== "" &&
     password !== "" &&
     confirm !== "";
-  const captchaRef = useRef(null);
-  const onLoad = () => {
-    captchaRef.current.execute();
-  };
-  // useEffect(() => {
-  //   if (state?.data?.user?.id) {
-  //     const user = state.data.user;
-  //     const identities = state.data.identities;
-  //     console.log(`state: ${JSON.stringify(state)}`);
-  //     captchaRef.current.resetCaptcha();
-  //     if (identities.length > 0) {
-  //       const identity = state.data.identities[0];
-  //       const captchaToken = identity.identity_data.captchaToken;
-  //       router.push(
-  //         `/account/check-email?captchaToken=${captchaToken}&email=${user.email}`
-  //       );
-  //     } else {
-  //       router.push(
-  //         `/account/check-email?captchaToken=null&email= ${user.email}`
-  //       );
-  //     }
-  //     //state.data?.identities[0]?.identity_data?.email_verified === false
-  //     //router.push("/account/check-email");
-  //   }
-  // }, [state, router, captchaRef]);
+
+  useEffect(() => {
+    if (state?.data?.user?.id) {
+      const user = state.data.user;
+      const encodedEmail = encodeURIComponent(user.email);
+      const identities = state.data.identities;
+      console.log(`state: ${JSON.stringify(state)}`);
+      // captchaRef.current.resetCaptcha();
+      let captchaToken = "";
+      if (identities.length > 0) {
+        const identity = state.data.identities[0];
+        captchaToken = identity.identity_data.captchaToken;
+      }
+      router.push(
+        `/account/check-email/${encodedEmail}?captchaToken=${captchaToken}&action=signup`
+      );
+      //state.data?.identities[0]?.identity_data?.email_verified === false
+      //router.push("/account/check-email");
+    }
+  }, [state, router]);
+
   function handleFirst(e) {
     setFirstName(e.target.value);
   }
@@ -66,7 +63,7 @@ function SignUpForm({ hCaptchaSiteKey }) {
   function handleConfirm(e) {
     setConfirm(e.target.value);
   }
-  console.log(hCaptchaSiteKey);
+  // console.log(token);
   return (
     <div className="w-full content-center">
       <form action={formAction}>
@@ -118,7 +115,7 @@ function SignUpForm({ hCaptchaSiteKey }) {
             />
           </div>
           <div className="flex p-2 justify-center">
-            <HCaptcha
+            {/* <HCaptcha
               sitekey={hCaptchaSiteKey}
               onLoad={onLoad}
               onVerify={setToken}
@@ -130,7 +127,7 @@ function SignUpForm({ hCaptchaSiteKey }) {
               name="captchaToken"
               value={token}
               readOnly={true}
-            />
+            /> */}
           </div>
           <div className="flex w-full content-center">
             <SubmitButton

--- a/src/app/_components/Welcome.js
+++ b/src/app/_components/Welcome.js
@@ -1,0 +1,17 @@
+"use client";
+import { useSession } from "../_contexts/SessionProvider";
+import Error from "../error";
+
+function Welcome() {
+  const { session } = useSession();
+  if (!session) {
+    return <div>Session not found</div>;
+  }
+  return (
+    <div className="text-2xl font-bold">
+      {session && <div>Welcome, {session.user.user_metadata.firstName}!</div>}
+    </div>
+  );
+}
+
+export default Welcome;

--- a/src/app/account/check-email/[email]/page.js
+++ b/src/app/account/check-email/[email]/page.js
@@ -1,23 +1,24 @@
 import ResendConfirmation from "@/src/app/_components/ResendConfirmation";
+import SignUpConfirmation from "@/src/app/_components/SignUpConfirmation";
 
 export default async function Page({ params }) {
-  const { email } = await params;
+  const { email, captchaToken, action } = await params;
   const decodedEmail = decodeURIComponent(email);
   return (
     <div className="w-full text-center text-lg text-primary-400 mb-4">
-      <h1>Check Your Email</h1>
-      <p>
-        Please check your email for a confirmation link to complete your account
-        setup.
-      </p>
-      <p>
-        If you don&apos;t see the email, please check your spam or junk folder.{" "}
-        <i>
-          Note: you won&apos;t receive another confirmation if you are already
-          signed up.
-        </i>
-      </p>
-      <ResendConfirmation email={decodedEmail} />
+      {action === "signup" && <SignUpConfirmation showNote={captchaToken} />}{" "}
+      {action === "reset" && (
+        <>
+          <p className="text-justify pb-0 text-xl font-semibold text-primary-200">
+            Check your email for a link to update your password.
+          </p>
+          <p className="text-justify pb-0 text-xl text-primary-300">
+            If you don&apos;t see the email, please check your spam or junk
+            folder.
+          </p>
+        </>
+      )}
+      <ResendConfirmation email={decodedEmail} action={action} />
     </div>
   );
 }

--- a/src/app/account/login/page.js
+++ b/src/app/account/login/page.js
@@ -13,14 +13,14 @@ function Page() {
         <div className="w-1/3"></div>
         <div className="text-center rounded-md py-4 w-1/3">
           <h1
-            className={`text-5xl text-accent-500 pb-5 ${rubikDoodleShadow.className}`}
+            className={`text-5xl text-accent-50 pb-5 ${rubikDoodleShadow.className}`}
           >
             Log In
           </h1>
           <p className="pb-1 text-primary-200">
             New customer?{" "}
             <Link
-              href="/account/signup"
+              href="/account/verify-human"
               className="border border-primary-700 py-1 px-2 rounded-md mx-2 text-lg inline-block hover:bg-accent-600 transition-all hover:text-primary-950"
             >
               Start here &rarr;
@@ -31,7 +31,7 @@ function Page() {
             Forgot your password?&nbsp;
             <Link
               href="/account/reset-password"
-              className="border border-primary-700 py-1 px-2 rounded-md mx-2 text-lg inline-block hover:bg-accent-600 transition-all hover:text-primary-950"
+              className="border border-primary-700 py-1 px-2 rounded-md mx-2 text-lg inline-block hover:bg-accent-600 transition-all hover:text-primary-50"
             >
               Reset Password &rarr;
             </Link>

--- a/src/app/account/reset-password/page.js
+++ b/src/app/account/reset-password/page.js
@@ -4,7 +4,7 @@ function Page() {
   return (
     <div className="relative flex grid-cols-3">
       <div className="w-1/3"></div>
-      <div className="text-center rounded-md py-4 bg-primary-700 w-1/3">
+      <div className="text-center rounded-md py-4 w-1/3">
         <ResetPasswordForm />
       </div>
       <div className="w-1/3"></div>

--- a/src/app/account/signup/page.js
+++ b/src/app/account/signup/page.js
@@ -1,7 +1,8 @@
 import SignUp from "@/src/app/_components/SignUp";
 
-function Page() {
-  return <SignUp />;
+async function Page({ searchParams }) {
+  const { captchaToken } = await searchParams;
+  return <SignUp captchaToken={captchaToken} />;
 }
 
 export default Page;

--- a/src/app/account/verify-human/page.js
+++ b/src/app/account/verify-human/page.js
@@ -1,0 +1,23 @@
+import React from "react";
+import SignUpCaptcha from "@/src/app/_components/SignUpCaptcha";
+
+const VerifyHumanPage = () => {
+  const siteKey = process.env.NEXT_HCAPTCHA_SITEKEY;
+
+  if (!siteKey) {
+    throw new Error("Error loading page.");
+  }
+
+  return (
+    <div className="relative flex grid-cols-3">
+      <div className="w-1/4"></div>
+      <div className="text-center rounded-md py-4 w-1/2">
+        <h1 className="text-xl font-bold">Verify You Are Human</h1>
+        <SignUpCaptcha siteKey={siteKey} />
+      </div>
+      <div className="w-1/4"></div>
+    </div>
+  );
+};
+
+export default VerifyHumanPage;

--- a/src/app/account/verify-human/page.js
+++ b/src/app/account/verify-human/page.js
@@ -1,11 +1,11 @@
 import React from "react";
 import SignUpCaptcha from "@/src/app/_components/SignUpCaptcha";
 
-const VerifyHumanPage = () => {
+export default function page() {
   const siteKey = process.env.NEXT_HCAPTCHA_SITEKEY;
 
   if (!siteKey) {
-    throw new Error("Error loading page.");
+    return <div>site key is missing</div>;
   }
 
   return (
@@ -18,6 +18,4 @@ const VerifyHumanPage = () => {
       <div className="w-1/4"></div>
     </div>
   );
-};
-
-export default VerifyHumanPage;
+}

--- a/src/app/api/auth/confirm/route.js
+++ b/src/app/api/auth/confirm/route.js
@@ -1,5 +1,6 @@
-import { NextResponse } from "next/server";
 import { createClient } from "@/src/app/_library/supabase/server";
+import { Base64Decoder, Base64Encoder } from "next-base64-encoder";
+import { NextResponse } from "next/server";
 
 export async function GET(request) {
   const { searchParams } = new URL(request.url);
@@ -17,6 +18,15 @@ export async function GET(request) {
       token_hash,
     });
     if (!error) {
+      return NextResponse.redirect(redirectTo);
+    } else {
+      console.log(error.message);
+      const byteMessage = new TextEncoder().encode(error.message);
+      const base64UrlDecoder = new Base64Decoder();
+      const base64Phrase = base64UrlDecoder.decode(byteMessage);
+      redirectTo.pathname = "/auth/auth-code-error";
+      redirectTo.searchParams.set("message", base64Phrase);
+      redirectTo.searchParams.set("next", next);
       return NextResponse.redirect(redirectTo);
     }
   }

--- a/src/app/auth/auth-code-error/page.js
+++ b/src/app/auth/auth-code-error/page.js
@@ -2,22 +2,34 @@ import { Base64UrlEncoder } from "next-base64-encoder";
 import Link from "next/link";
 
 async function Page({ searchParams }) {
-  const { message } = await searchParams;
+  const { message, next } = await searchParams;
   let decodedMessage = null;
   if (message) {
     const base64UrlEncoder = new Base64UrlEncoder();
     const byteMessage = base64UrlEncoder.encode(message);
     decodedMessage = new TextDecoder().decode(byteMessage);
   }
+  let nextPath = "/account/signup";
+  let confirmationType = "sign up";
+  switch (decodeURIComponent(next)) {
+    case "/account/update-password":
+      nextPath = "/account/reset-password";
+      confirmationType = "reset password";
+      break;
+    case "/welcome":
+      nextPath = "/account/signup";
+      break;
+  }
   return (
     <main className="flex justify-center items-center flex-col gap-6">
-      <h1 className="text-3xl font-semibold">
-        Oops! Something went wrong with your sign up confirmation... 🤒
+      <h1 className="text-2xl font-semibold">
+        Oops! Something went wrong with your {confirmationType} confirmation...
+        🤒
       </h1>
       {decodedMessage && <p className="text-lg">{decodedMessage}</p>}
       <p className="text-lg">
         Please{" "}
-        <Link className="font-bold" href="/signup">
+        <Link className="font-bold" href={nextPath}>
           try again
         </Link>{" "}
         or{" "}

--- a/src/app/welcome/page.js
+++ b/src/app/welcome/page.js
@@ -1,15 +1,16 @@
-"use client";
-
-import { useSession } from "@/src/app/_contexts/SessionProvider";
-import Error from "@/src/app/error";
+import Link from "next/link";
+import Welcome from "../_components/Welcome";
 
 function Page() {
-  const { session } = useSession();
-
-  if (!session) return <Error error={{ message: "Sign Up failed." }} />;
   return (
-    <div>
-      {session && <div>Welcome, {session.user.user_metadata.firstName}!</div>}
+    <div className="flex flex-col items-center justify-normal mt-5 min-h-screen">
+      <Welcome />
+      <Link
+        href="/"
+        className="border border-primary-700 py-1 px-2 rounded-md mx-2 mt-2 text-lg font-bold inline-block hover:bg-accent-600 transition-all hover:text-primary-50"
+      >
+        Continue Shopping &rarr;
+      </Link>
     </div>
   );
 }


### PR DESCRIPTION
Changes:

- added `.vscode` to the `.gitignore` file
- created a new `/account/verify-human` page for hCaptcha and put it before the signup form
- changed link in `ComingSoonSmall.js` to point to `/account/verify-human`
- adding styling to toast call in `LoginForm.js`
- modified `Navigation.js` to have `Join` instead of `Sign Up`
- added a switch to decide what server action to use in `ResendConfirmation.js`
- added `action` query string param to send to `/account/check-email` to indicate what action we're checking the email for (e.g., reset password, signup, etc.)
- added `captchaToken` prop to `SignUp.js`
- added new`SignUpCaptcha.js` component
- added new`SignUpConfirmation.js` component
- removed hCaptcha component import from `SignUpForm.js`
- added new `Welcome.js` component
- update `/account/check-email/[email]/page.js` to accommodate different types of confirmations
- updated styling in the `/account/login/page.js` and changed new customer link to navigate to `/account/verify-human`
- updated `/account/reset-password/page.js` styling
- updated `/account/signup/page.js` to extract captchaToken from searchParams and pass it to the `SignUp.js` component
- created `/account/verify-human` page to serve captcha before taking user to signup.
- modified `/api/auth/confirm/route.js` to encode error message in base64 to pass to `/auth/auth-code-error`
- modified `/auth/auth-code-error/page.js` to decode base64 message (if exists) and added switch to determine which action should be taken on `Try again` based on the `next` query string parameter
- moved `useSession` into new `Welcome.js` client component to avoid hydration blip when `/welcome/page.js` was loading.
 