### PR TITLE
updated the tailwind/link.jsx component to use next/link

### DIFF
--- a/src/app/_components/tailwind/link.jsx
+++ b/src/app/_components/tailwind/link.jsx
@@ -6,13 +6,14 @@
  * https://catalyst.tailwindui.com/docs#client-side-router-integration
  */
 
-import * as Headless from '@headlessui/react'
-import React, { forwardRef } from 'react'
+import * as Headless from "@headlessui/react";
+import React, { forwardRef } from "react";
+import NextLink from "next/link";
 
 export const Link = forwardRef(function Link(props, ref) {
   return (
     <Headless.DataInteractive>
-      <a {...props} ref={ref} />
+      <NextLink {...props} ref={ref} />
     </Headless.DataInteractive>
-  )
-})
+  );
+});


### PR DESCRIPTION
By default, the TailwindPlus Catalyst component library's `link.jsx` uses the `<a>...</a>` anchor tag for links.  Updated it to use the `<Link />` component from `next/link`.