### PR TITLE
fixed getURL server function to point to the correct url in prod

### DIFF
--- a/src/app/_library/serverActions.js
+++ b/src/app/_library/serverActions.js
@@ -76,8 +76,7 @@ async function serverGetRecords(id = null, limit = 10) {
 
 const getURL = () => {
   let url =
-    process?.env?.NEXT_PUBLIC_SITE_URL ?? // Set this to your site URL in production env.
-    process?.env?.NEXT_PUBLIC_VERCEL_URL ?? // Automatically set by Vercel.
+    process?.env?.VERCEL_URL ?? // Set this to your site URL in production env.
     "http://localhost:3000/";
   // Make sure to include `https://` when not localhost.
   url = url.startsWith("http") ? url : `https://${url}`;


### PR DESCRIPTION
Originally created `getURL` server function based on NEXT.js documentation that appears to be outdated.  Updated to point to the `VERCEL_URL` in production (it was always redirecting to a deployment branch URL rather than production)