### PR TITLE
fixing the prod url by removing the protocol

### DIFF
--- a/src/app/_library/serverActions.js
+++ b/src/app/_library/serverActions.js
@@ -75,7 +75,9 @@ async function serverGetRecords(id = null, limit = 10) {
 }
 
 const getURL = () => {
+  // NOTE: environment URLs other than localhost should have no protocol, e.g., my-site.vercel.app
   let url =
+    process?.env?.NEXT_PUBLIC_SITE_URL ?? // Set this to your site URL in production env.
     process?.env?.VERCEL_URL ?? // Set this to your site URL in production env.
     "http://localhost:3000/";
   // Make sure to include `https://` when not localhost.


### PR DESCRIPTION
I had mistakenly added the `https://` to the URL.  Removed it.